### PR TITLE
fix: mercury shortcut

### DIFF
--- a/bucket/mercury-avx.json
+++ b/bucket/mercury-avx.json
@@ -15,8 +15,7 @@
     "shortcuts": [
         [
             "mercury.exe",
-            "Mercury",
-            "MERCURY.BAT"
+            "Mercury"
         ]
     ],
     "persist": [

--- a/bucket/mercury-avx2.json
+++ b/bucket/mercury-avx2.json
@@ -15,8 +15,7 @@
     "shortcuts": [
         [
             "mercury.exe",
-            "Mercury",
-            "MERCURY.BAT"
+            "Mercury"
         ]
     ],
     "persist": [

--- a/bucket/mercury.json
+++ b/bucket/mercury.json
@@ -15,8 +15,7 @@
     "shortcuts": [
         [
             "mercury.exe",
-            "Mercury",
-            "MERCURY.BAT"
+            "Mercury"
         ]
     ],
     "persist": [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
Remove unnecessary launch parameter, otherwise it will open `http://mercury.bat` every time it starts

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
